### PR TITLE
add guard

### DIFF
--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -45,6 +45,7 @@ function PDF (html, options) {
 PDF.prototype.toBuffer = function PdfToBuffer (callback) {
   this.exec(function execPdfToBuffer (err, res) {
     if (err) return callback(err)
+    if (!res || !res.filename) return callback(new Error('No PDF found unable to convert to buffer'))
     fs.readFile(res.filename, function readCallback (err, buffer) {
       if (err) return callback(err)
       fs.unlink(res.filename, function unlinkPdfFile (err) {


### PR DESCRIPTION
Summary: Errors in the html to pdf lib were causing coversheets to not generate. Those errors were "uncatchable" and could only be caught by the process.on which is not a good candidate for use in lambdas. This package is deprecated so it has been forked so that we could adjust it to fit our needs.
Concerns: none
Tests: Local 